### PR TITLE
Revert "Update checkstyle.xml"

### DIFF
--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -117,7 +117,7 @@
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
         <module name="MemberName">
-            <property name="format" value="^[a-z][a-zA-Z0-9]+$"/>
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
This reverts commit 4192898d259eba2702e328c04a5bdf752ab05578.

This change allowed property names to start with a one character long camel-segment. Like `uValue`. This causes all sorts of problems when converting between cases. Especially mapstruct seems to be unable to find the right getters and setter when converting between classes (getter with `get` prefix) and records (getter named like the property).

See https://linear.app/aboutbits/issue/FINC-286/fix-naming-issue