### PR TITLE
Add AssertJ 3.27.7 and replace JUnit assertions in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <checkstyle.version>13.4.2</checkstyle.version>
         <junit.version>6.1.0</junit.version>
+        <assertj.version>3.27.7</assertj.version>
         <errorprone.version>2.49.0</errorprone.version>
         <nullaway.version>0.13.4</nullaway.version>
     </properties>
@@ -35,6 +36,13 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/org.assertj/assertj-core -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/it/aboutbits/checkstyle/JSpecifyAnnotationOrderCheckTest.java
+++ b/src/test/java/it/aboutbits/checkstyle/JSpecifyAnnotationOrderCheckTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @NullMarked
 class JSpecifyAnnotationOrderCheckTest extends CheckTestSupport {
@@ -17,28 +16,28 @@ class JSpecifyAnnotationOrderCheckTest extends CheckTestSupport {
     @Test
     void jspecifyAnnotationAsLastPasses() throws Exception {
         var v = runCheck(JSpecifyAnnotationOrderCheck.class, BASE + "GoodLast.java");
-        assertEquals(List.of(), v);
+        assertThat(v).isEmpty();
     }
 
     @Test
     void jspecifyAnnotationFollowedByOtherFailsAndHighlightsCloseAnnotation() throws Exception {
         var v = runCheck(JSpecifyAnnotationOrderCheck.class, BASE + "BadInMiddle.java");
-        assertEquals(1, v.size());
-        assertTrue(v.getFirst().contains(NullMarked.class.getSimpleName()), v.toString());
-        assertTrue(v.getFirst().startsWith("6:"), "violation should be reported on the @NullMarked line: " + v);
+        assertThat(v).hasSize(1);
+        assertThat(v.getFirst()).contains(NullMarked.class.getSimpleName());
+        assertThat(v.getFirst()).startsWith("6:");
     }
 
     @Test
     void jspecifyAnnotationAsFirstFailsAndHighlightsCloseAnnotation() throws Exception {
         var v = runCheck(JSpecifyAnnotationOrderCheck.class, BASE + "BadFirst.java");
-        assertEquals(1, v.size());
-        assertTrue(v.getFirst().startsWith("5:"), "violation should be reported on the @NullMarked line: " + v);
+        assertThat(v).hasSize(1);
+        assertThat(v.getFirst()).startsWith("5:");
     }
 
     @Test
     void noJspecifyAnnotationDoesNotFire() throws Exception {
         var v = runCheck(JSpecifyAnnotationOrderCheck.class, BASE + "NoJSpecify.java");
-        assertEquals(List.of(), v);
+        assertThat(v).isEmpty();
     }
 
     @Test
@@ -46,11 +45,11 @@ class JSpecifyAnnotationOrderCheckTest extends CheckTestSupport {
         var properties = Map.of("closeAnnotations", "Custom,AnotherClose");
 
         var ok = runCheck(JSpecifyAnnotationOrderCheck.class, BASE + "CustomCloseLast.java", properties);
-        assertEquals(List.of(), ok);
+        assertThat(ok).isEmpty();
 
         var bad = runCheck(JSpecifyAnnotationOrderCheck.class, BASE + "CustomCloseInMiddle.java", properties);
-        assertEquals(1, bad.size());
-        assertTrue(bad.getFirst().contains("Custom"), bad.toString());
+        assertThat(bad).hasSize(1);
+        assertThat(bad.getFirst()).contains("Custom");
     }
 
     @Test
@@ -60,6 +59,6 @@ class JSpecifyAnnotationOrderCheckTest extends CheckTestSupport {
                 BASE + "GoodLast.java",
                 Map.of("closeAnnotations", "  NullMarked , NullUnmarked  ")
         );
-        assertEquals(List.of(), v);
+        assertThat(v).isEmpty();
     }
 }

--- a/src/test/java/it/aboutbits/checkstyle/JSpecifyInlineTypeUseCheckTest.java
+++ b/src/test/java/it/aboutbits/checkstyle/JSpecifyInlineTypeUseCheckTest.java
@@ -3,9 +3,7 @@ package it.aboutbits.checkstyle;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @NullMarked
 class JSpecifyInlineTypeUseCheckTest extends CheckTestSupport {
@@ -14,67 +12,61 @@ class JSpecifyInlineTypeUseCheckTest extends CheckTestSupport {
 
     @Test
     void inlineMethodReturnPasses() throws Exception {
-        assertEquals(List.of(), runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "GoodInlineMethod.java"));
+        assertThat(runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "GoodInlineMethod.java")).isEmpty();
     }
 
     @Test
     void inlineFieldPasses() throws Exception {
-        assertEquals(List.of(), runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "GoodInlineField.java"));
+        assertThat(runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "GoodInlineField.java")).isEmpty();
     }
 
     @Test
     void inlineParameterPasses() throws Exception {
-        assertEquals(List.of(), runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "GoodInlineParameter.java"));
+        assertThat(runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "GoodInlineParameter.java")).isEmpty();
     }
 
     @Test
     void inlineLocalPasses() throws Exception {
-        assertEquals(List.of(), runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "GoodInlineLocal.java"));
+        assertThat(runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "GoodInlineLocal.java")).isEmpty();
     }
 
     @Test
     void annotationOnLineAboveMethodFails() throws Exception {
         var v = runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "BadAboveMethod.java");
-        assertEquals(1, v.size(), v.toString());
+        assertThat(v).hasSize(1);
     }
 
     @Test
     void annotationOnLineAboveFieldFails() throws Exception {
         var v = runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "BadAboveField.java");
-        assertEquals(1, v.size(), v.toString());
+        assertThat(v).hasSize(1);
     }
 
     @Test
     void annotationOnLineAboveParameterFails() throws Exception {
         var v = runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "BadAboveParameter.java");
-        assertEquals(1, v.size(), v.toString());
+        assertThat(v).hasSize(1);
     }
 
     @Test
     void annotationOnLineAboveLocalFails() throws Exception {
         var v = runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "BadAboveLocal.java");
-        assertEquals(1, v.size(), v.toString());
+        assertThat(v).hasSize(1);
     }
 
     @Test
     void nonJspecifyNullableImportedFromElsewhereIsIgnored() throws Exception {
-        assertEquals(
-                List.of(),
-                runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "NonJSpecifyNullableAboveFieldIgnored.java")
-        );
+        assertThat(runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "NonJSpecifyNullableAboveFieldIgnored.java")).isEmpty();
     }
 
     @Test
     void nonJspecifyFullyQualifiedNullableIsIgnored() throws Exception {
-        assertEquals(
-                List.of(),
-                runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "NonJSpecifyFqnNullableAboveFieldIgnored.java")
-        );
+        assertThat(runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "NonJSpecifyFqnNullableAboveFieldIgnored.java")).isEmpty();
     }
 
     @Test
     void fullyQualifiedJspecifyNullableAboveFieldFails() throws Exception {
         var v = runCheck(JSpecifyInlineTypeUseCheck.class, BASE + "JSpecifyFqnAboveFieldFails.java");
-        assertEquals(1, v.size(), v.toString());
+        assertThat(v).hasSize(1);
     }
 }

--- a/src/test/java/it/aboutbits/checkstyle/JSpecifyMapStructMapperAnnotationCheckTest.java
+++ b/src/test/java/it/aboutbits/checkstyle/JSpecifyMapStructMapperAnnotationCheckTest.java
@@ -3,11 +3,9 @@ package it.aboutbits.checkstyle;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @NullMarked
 class JSpecifyMapStructMapperAnnotationCheckTest extends CheckTestSupport {
@@ -16,42 +14,36 @@ class JSpecifyMapStructMapperAnnotationCheckTest extends CheckTestSupport {
 
     @Test
     void wellOrderedMapperPasses() throws Exception {
-        assertEquals(List.of(), runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "GoodMapper.java"));
+        assertThat(runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "GoodMapper.java")).isEmpty();
     }
 
     @Test
     void mapperWithNamedValueArgumentPasses() throws Exception {
-        assertEquals(
-                List.of(),
-                runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "GoodMapperNamedValue.java")
-        );
+        assertThat(runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "GoodMapperNamedValue.java")).isEmpty();
     }
 
     @Test
     void swappedOrderFails() throws Exception {
         var v = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "BadOrderSwapped.java");
-        assertEquals(1, v.size());
-        assertTrue(v.getFirst().contains("BadOrderSwapped"), v.toString());
+        assertThat(v).hasSize(1);
+        assertThat(v.getFirst()).contains("BadOrderSwapped");
     }
 
     @Test
     void missingAnnotateWithFails() throws Exception {
         var v = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "BadMissingAnnotateWith.java");
-        assertEquals(1, v.size());
+        assertThat(v).hasSize(1);
     }
 
     @Test
     void annotateWithWrongClassLiteralFails() throws Exception {
         var v = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "BadWrongClassLiteral.java");
-        assertEquals(1, v.size());
+        assertThat(v).hasSize(1);
     }
 
     @Test
     void interfaceWithoutMapperIsIgnored() throws Exception {
-        assertEquals(
-                List.of(),
-                runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "NonMapperInterfaceIgnored.java")
-        );
+        assertThat(runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "NonMapperInterfaceIgnored.java")).isEmpty();
     }
 
     @Test
@@ -59,11 +51,11 @@ class JSpecifyMapStructMapperAnnotationCheckTest extends CheckTestSupport {
         var properties = Map.of("mapperAnnotationName", "MyMapper");
 
         var ok = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "CustomMapperGood.java", properties);
-        assertEquals(List.of(), ok);
+        assertThat(ok).isEmpty();
 
         var bad = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "CustomMapperBad.java", properties);
-        assertEquals(1, bad.size());
-        assertTrue(bad.getFirst().contains("CustomMapperBad"), bad.toString());
+        assertThat(bad).hasSize(1);
+        assertThat(bad.getFirst()).contains("CustomMapperBad");
     }
 
     @Test
@@ -71,10 +63,10 @@ class JSpecifyMapStructMapperAnnotationCheckTest extends CheckTestSupport {
         var properties = Map.of("annotateWithAnnotationName", "MyAnnotateWith");
 
         var ok = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "CustomAnnotateWithGood.java", properties);
-        assertEquals(List.of(), ok);
+        assertThat(ok).isEmpty();
 
         var bad = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "GoodMapper.java", properties);
-        assertEquals(1, bad.size(), bad.toString());
+        assertThat(bad).hasSize(1);
     }
 
     @Test
@@ -82,32 +74,26 @@ class JSpecifyMapStructMapperAnnotationCheckTest extends CheckTestSupport {
         var properties = Map.of("nullUnmarkedAnnotationName", "MyUnmarked");
 
         var ok = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "CustomNullUnmarkedGood.java", properties);
-        assertEquals(List.of(), ok);
+        assertThat(ok).isEmpty();
 
         var bad = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "GoodMapper.java", properties);
-        assertEquals(1, bad.size(), bad.toString());
+        assertThat(bad).hasSize(1);
     }
 
     @Test
     void wellOrderedAbstractClassMapperPasses() throws Exception {
-        assertEquals(
-                List.of(),
-                runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "GoodAbstractMapper.java")
-        );
+        assertThat(runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "GoodAbstractMapper.java")).isEmpty();
     }
 
     @Test
     void abstractClassMapperWithSwappedOrderFails() throws Exception {
         var v = runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "BadAbstractMapperOrderSwapped.java");
-        assertEquals(1, v.size());
-        assertTrue(v.getFirst().contains("BadAbstractMapperOrderSwapped"), v.toString());
+        assertThat(v).hasSize(1);
+        assertThat(v.getFirst()).contains("BadAbstractMapperOrderSwapped");
     }
 
     @Test
     void nonAbstractClassWithMapperAnnotationIsIgnored() throws Exception {
-        assertEquals(
-                List.of(),
-                runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "NonAbstractClassWithMapperAnnotationIgnored.java")
-        );
+        assertThat(runCheck(JSpecifyMapStructMapperAnnotationCheck.class, BASE + "NonAbstractClassWithMapperAnnotationIgnored.java")).isEmpty();
     }
 }

--- a/src/test/java/it/aboutbits/checkstyle/JSpecifyOnTopLevelTypesCheckTest.java
+++ b/src/test/java/it/aboutbits/checkstyle/JSpecifyOnTopLevelTypesCheckTest.java
@@ -3,10 +3,7 @@ package it.aboutbits.checkstyle;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @NullMarked
 class JSpecifyOnTopLevelTypesCheckTest extends CheckTestSupport {
@@ -16,44 +13,44 @@ class JSpecifyOnTopLevelTypesCheckTest extends CheckTestSupport {
     @Test
     void classMarkedWithNullMarkedPasses() throws Exception {
         var v = runCheck(JSpecifyOnTopLevelTypesCheck.class, BASE + "GoodMarked.java");
-        assertEquals(List.of(), v);
+        assertThat(v).isEmpty();
     }
 
     @Test
     void classMarkedWithNullUnmarkedPasses() throws Exception {
         var v = runCheck(JSpecifyOnTopLevelTypesCheck.class, BASE + "GoodUnmarked.java");
-        assertEquals(List.of(), v);
+        assertThat(v).isEmpty();
     }
 
     @Test
     void fullyQualifiedJspecifyAnnotationPasses() throws Exception {
         var v = runCheck(JSpecifyOnTopLevelTypesCheck.class, BASE + "GoodFullyQualified.java");
-        assertEquals(List.of(), v);
+        assertThat(v).isEmpty();
     }
 
     @Test
     void classWithoutJspecifyAnnotationFails() throws Exception {
         var v = runCheck(JSpecifyOnTopLevelTypesCheck.class, BASE + "BadMissing.java");
-        assertEquals(1, v.size());
-        assertTrue(v.getFirst().contains("BadMissing"), v.toString());
+        assertThat(v).hasSize(1);
+        assertThat(v.getFirst()).contains("BadMissing");
     }
 
     @Test
     void annotationDeclarationIsExempt() throws Exception {
         var v = runCheck(JSpecifyOnTopLevelTypesCheck.class, BASE + "AnnotationDefExempt.java");
-        assertEquals(List.of(), v);
+        assertThat(v).isEmpty();
     }
 
     @Test
     void nestedClassIsNotChecked() throws Exception {
         var v = runCheck(JSpecifyOnTopLevelTypesCheck.class, BASE + "NestedClassOnly.java");
-        assertEquals(List.of(), v);
+        assertThat(v).isEmpty();
     }
 
     @Test
     void recordWithoutJspecifyFails() throws Exception {
         var v = runCheck(JSpecifyOnTopLevelTypesCheck.class, BASE + "BadRecord.java");
-        assertEquals(1, v.size());
-        assertTrue(v.getFirst().contains("BadRecord"), v.toString());
+        assertThat(v).hasSize(1);
+        assertThat(v.getFirst()).contains("BadRecord");
     }
 }


### PR DESCRIPTION
Replaces all JUnit `Assertions.assertEquals` / `assertTrue` calls in the four test classes with AssertJ `assertThat(...)` equivalents, and adds `assertj-core 3.27.7` as a test dependency in `pom.xml`.

**Changes:**
- `pom.xml` — adds `assertj.version` property and `assertj-core` test dependency
- `JSpecifyAnnotationOrderCheckTest` — converted to AssertJ
- `JSpecifyOnTopLevelTypesCheckTest` — converted to AssertJ
- `JSpecifyMapStructMapperAnnotationCheckTest` — converted to AssertJ
- `JSpecifyInlineTypeUseCheckTest` — converted to AssertJ

All 6 tests in `JSpecifyAnnotationOrderCheckTest` verified green locally after the change.

⚠️ Merge this PR before the parent PR #10.

Parent PR: https://github.com/aboutbits/java-checkstyle-config/pull/10

CI runs full verification.